### PR TITLE
Add simple Telegram webhook bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# FlirtHelper
+# FlirtHelper Telegram Bot
+
+Простейший Telegram-бот, который отвечает на любое сообщение текстом:
+
+```
+Новый бот для переписок - @VibeDatingBot
+```
+
+## Деплой на Vercel
+
+1. Создайте новый проект на Vercel и импортируйте этот репозиторий.
+2. В настройках проекта добавьте переменную окружения `TELEGRAM_BOT_TOKEN` со значением токена бота.
+3. Задеплойте проект. После деплоя Vercel предоставит публичный URL.
+4. Настройте webhook в Telegram:
+   ```bash
+   curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook?url=https://<your-project>.vercel.app/api/webhook"
+   ```
+5. Отправьте сообщение боту в Telegram — он ответит заданной фразой.
+
+## Локальное тестирование
+
+Для отправки тестового запроса можно использовать `curl`:
+
+```bash
+curl -X POST \
+  https://<your-project>.vercel.app/api/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"message":{"chat":{"id":12345}}}'
+```
+
+При развертывании в продакшн на Vercel дополнительная конфигурация не требуется.

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,0 +1,44 @@
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.status(200).json({ ok: true, message: "Use POST with Telegram webhook payload." });
+    return;
+  }
+
+  const rawBody = req.body;
+  const body = typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody;
+  const message = body?.message;
+
+  if (!message?.chat?.id) {
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  const chatId = message.chat.id;
+  const text = "Новый бот для переписок - @VibeDatingBot";
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+
+  if (!token) {
+    res.status(500).json({ ok: false, error: "TELEGRAM_BOT_TOKEN is not set." });
+    return;
+  }
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Telegram API error:", errorText);
+      res.status(500).json({ ok: false });
+      return;
+    }
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error("Failed to call Telegram API:", error);
+    res.status(500).json({ ok: false });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "flirthelper-bot",
+  "version": "1.0.0",
+  "description": "Simple Telegram bot replying with a fixed message",
+  "main": "api/webhook.js",
+  "type": "module",
+  "scripts": {
+    "start": "vercel dev"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vercel-compatible webhook handler that responds to every Telegram message with the promo text
- document deployment steps and environment setup for the bot

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d139f4ce5c832485d254b4aae89fdf